### PR TITLE
fix: Linux/Proton playermodel mounting

### DIFF
--- a/lua/wardrobe/gmamalicious.lua
+++ b/lua/wardrobe/gmamalicious.lua
@@ -64,11 +64,15 @@ end
 
 function gmamalicious.modelExists(mdl)
 	local m = mdl:gsub("%.mdl$", "")
-	return file.Exists(m .. ".mdl", "GAME")
+	local exists = file.Exists(m .. ".mdl", "GAME")
+	if not exists then
+		print("GMA Malicious | modelExists FAILED for: " .. tostring(mdl))
+	end
+	return exists
 end
 
-local pat  = [==[.+%(%s-["|'](.+)["|'],%s-["|'](.-)["|']%s-%)]==]
-local pat2 = [==[.+%(%s-["|'](.+)["|'],%s-["|'](.-)["|'],%s-(%d+),%s-["|'](.+)["|']%s-%)]==]
+local pat  = [==[.+%(%s-["|'](.+)["|']%s-,%s-["|'](.-)["|']%s-%)]==]
+local pat2 = [==[.+%(%s-["|'](.+)["|']%s-,%s-["|'](.-)["|']%s-,%s-(%d+)%s-,%s-["|'](.+)["|']%s-.*%)]==]
 local function _playermanagerMatch(s, ext)
 	local name, mdl, a, b = s:match(ext and pat2 or pat)
 	if not (name and mdl) then return end
@@ -106,7 +110,7 @@ function gmamalicious.getPlayerModels(location, handle, showMetaLess)
 	for i, entry in ipairs(gma:filesMatching("lua/autorun/.+%.lua")) do
 		local path = entry.name
 
-		local f = file.Read(path, "GAME")
+		local f = gma:readEntry(entry) or file.Read(path, "GAME")
 		if f then
 			local lines = f:Split("\n")
 
@@ -145,7 +149,7 @@ function gmamalicious.getPlayerModels(location, handle, showMetaLess)
 	local pmerr
 
 	for i, entry in pairs(mdls) do
-		local noext = entry.name:sub(1, -5)
+		local noext = entry.name:sub(1, -5):lower()
 		local ok = extraMdlFiles[noext]
 
 		if ok then

--- a/lua/wardrobe/sv.lua
+++ b/lua/wardrobe/sv.lua
@@ -205,7 +205,7 @@ net.Receive("wardrobe.requestmodel", function(len, ply)
 
 	if not wsid then return end
 
-	if wardrobe.config.blacklistIds[wsid] then
+	if wardrobe.config.blacklistIds[tostring(wsid)] then
 		return print("Wardrobe | Blacklisted addon id was requested by player " .. ply:Nick() .. " (" .. wsid .. ")")
 	end
 	if wardrobe.config.blacklistFiles[mdl] then

--- a/lua/wardrobe/workshop.lua
+++ b/lua/wardrobe/workshop.lua
@@ -17,7 +17,7 @@ WS_DOWNLOADFAILED = 3
 WS_MISSINGFILE    = 4
 
 workshop.reverseEnum = {
-	[-1] = "Unknown",
+	[-100] = "Unknown", -- TODO: make this less ugly
 	"WS_NOFILEINFO",
 	"WS_FILETOOBIG",
 	"WS_DOWNLOADFAILED",
@@ -29,10 +29,12 @@ local IGNORE = function() end
 function workshop.err(wsid, reason)
 	workshop.currentQueueSize = workshop.currentQueueSize - 1
 
-	workshop.got[wsid] = false
+	workshop.got[wsid] = nil
 	workshop.reasons[wsid] = reason
 
-	err("Workshop | Error getting '" .. wsid  .. "', code: ", reason, " (" .. workshop.reverseEnum[reason] .. ")")
+	reason_str = workshop.reverseEnum[reason] or gmamalicious.reverseEnum[reason] or reason
+
+	err("Workshop | Error getting '" .. wsid  .. "' (" .. reason_str .. ")")
 end
 
 workshop.maxsize = wardrobe and wardrobe.config.maxFileSize or 0
@@ -55,7 +57,7 @@ do
 
 		local ok, _err = validate(wsid, fileInfo)
 		if ok == false then
-			return workshop.err(wsid, _err or -1)
+			return workshop.err(wsid, _err or -100)
 		end
 
 		print("Workshop | Downloading", wsid)
@@ -68,22 +70,40 @@ do
 		if date > compare_date then
 			print("Workshop | New addon format, if workshop gives up (hangs on LOADING) then you should too")
 
-			steamworks.DownloadUGC(wsid, function(path, handle)
-				if not path then
-					return workshop.err(wsid, WS_DOWNLOADFAILED)
-				end
+				steamworks.DownloadUGC(wsid, function(path, handle)
+				    if not path then
+				        return workshop.err(wsid, WS_DOWNLOADFAILED)
+				    end
 
-				-- if not file.Exists(path, "MOD") then
-				-- 	return workshop.err(wsid, WS_MISSINGFILE)
-				-- end
+				    print("Workshop | Path:", path)
 
-				print("Workshop | Path:", path)
+				    -- On Linux/Proton the path is a Wine virtual drive (e.g. S:/...)
+				    -- which game.MountGMA cannot resolve. Copy to DATA so we have a real path.
+				    local safePathRel = "wardrobe_cache/" .. wsid .. ".gma"
+				    local safePathAbs = "data/" .. safePathRel
 
-				workshop.got[wsid] = nil -- why? BECAUSE IT CANNOT BE REREAD AFTER HANDLE DIES, FUCKING GARBAGE
-				workshop.reasons[wsid] = path
+				    if not file.IsDir("wardrobe_cache", "DATA") then
+				        file.CreateDir("wardrobe_cache")
+				    end
 
-				callback(path, fileInfo, false, true, handle)
-			end)
+				    if not file.Exists(safePathAbs, "GAME") then
+				        print("Workshop | Copying GMA to safe path:", safePathAbs)
+				        local size = handle:Size()
+				        handle:Seek(0)
+				        local data = handle:Read(size)
+				        if not data then
+				            return workshop.err(wsid, WS_DOWNLOADFAILED)
+				        end
+				        file.Write(safePathRel, data)
+				    else
+				        print("Workshop | Safe path already exists, skipping copy")
+				    end
+
+				    workshop.got[wsid] = nil
+				    workshop.reasons[wsid] = safePathAbs
+
+				    callback(safePathAbs, fileInfo, false, true, handle)
+				end)
 
 			return
 		end


### PR DESCRIPTION
Fixes the issue reported by users on Linux/Proton where playermodels would download correctly but never apply.

- `steamworks.DownloadUGC` on Linux/Proton returns a Wine virtual drive path 
  (e.g. `S:/workshop/content/...`) that `game.MountGMA` cannot resolve. Fixed 
  by copying the GMA to `data/wardrobe_cache/<wsid>.gma` before mounting.

- `extraMdlFiles` stored `.vvd`/`.vtx` paths lowercased but looked them up 
  with the original casing from the GMA, silently dropping all models from 
  addons with uppercase in their paths.

- `file.Read(path, "GAME")` for lua autorun files fails if the mounted GMA 
  isn't yet visible in the GAME filesystem. Fixed by reading from the GMA 
  handle directly with a fallback to GAME filesystem.

This shouldn't upset the windows version!!
Tested on Fedora via Proton.

